### PR TITLE
Fix Dockerfile typo

### DIFF
--- a/DiscordEventBot.Service/Dockerfile
+++ b/DiscordEventBot.Service/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /src
 COPY ["DiscordEventBot.Service/DiscordEventBot.Service.csproj", "DiscordEventBot.Service/"]
 COPY ["DiscordEventBot.Model/DiscordEventBot.Model.csproj", "DiscordEventBot.Model/"]
 COPY ["DiscordEventBot.Common/DiscordEventBot.Common.csproj", "DiscordEventBot.Common/"]
-COPY ["DiscordEventBot.Common/DiscordEventBot.Jobs.csproj", "DiscordEventBot.Jobs/"]
+COPY ["DiscordEventBot.Jobs/DiscordEventBot.Jobs.csproj", "DiscordEventBot.Jobs/"]
 RUN dotnet restore "DiscordEventBot.Service/DiscordEventBot.Service.csproj"
 COPY . .
 WORKDIR "/src/DiscordEventBot.Service"


### PR DESCRIPTION
This looks to be a typo, I believe this should be picking up the DiscordEventBot.Jobs directory (for the Jobs csproj)